### PR TITLE
Add serde feature for Ltree value.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_ltree"
-version = "0.3.1"
+version = "0.4.0"
 # Currently maintained by Conner Bradley, originally written by Ashe Connor
 authors = ["Conner Bradley <bradley@advtech.ca>", "Ashe Connor <ashe@kivikakk.ee>"]
 description = "Adds support for the PostgreSQL ltree extension to Diesel"
@@ -12,11 +12,15 @@ repository = "https://github.com/kivikakk/diesel_ltree"
 
 [dependencies]
 byteorder = "1.0"
-diesel = { version = "2.0", default-features = false, features = [
+diesel = { version = "2.2", default-features = false, features = [
     "postgres_backend",
 ] }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 dotenv = "0.15"
-diesel = { version = "2.0", default-features = false, features = ["postgres"] }
+diesel = { version = "2.2", default-features = false, features = ["postgres"] }
 diesel_migrations = "2.0"
+
+[features]
+serde = ["dep:serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ pub mod values {
 
     /// A ltree [label path](https://www.postgresql.org/docs/current/ltree.html#LTREE-DEFINITIONS).
     #[derive(Debug, PartialEq, Eq, Clone, FromSqlRow, AsExpression)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(transparent))]
     #[diesel(sql_type = crate::sql_types::Ltree)]
     pub struct Ltree(pub String);
 
@@ -96,18 +98,18 @@ pub mod functions {
     use crate::sql_types::*;
     use diesel::sql_types::*;
 
-    sql_function!(fn subltree(ltree: Ltree, start: Int4, end: Int4) -> Ltree);
-    sql_function!(fn subpath(ltree: Ltree, offset: Int4, len: Int4) -> Ltree);
-    // sql_function!(fn subpath(ltree: Ltree, offset: Int4) -> Ltree);
-    sql_function!(fn nlevel(ltree: Ltree) -> Int4);
-    //sql_function!(fn index(a: Ltree, b: Ltree) -> Int4);
-    sql_function!(fn index(a: Ltree, b: Ltree, offset: Int4) -> Int4);
-    sql_function!(fn text2ltree(text: Text) -> Ltree);
-    sql_function!(fn ltree2text(ltree: Ltree) -> Text);
-    sql_function!(fn lca(ltrees: Array<Ltree>) -> Ltree);
+    define_sql_function!(fn subltree(ltree: Ltree, start: Int4, end: Int4) -> Ltree);
+    define_sql_function!(fn subpath(ltree: Ltree, offset: Int4, len: Int4) -> Ltree);
+    // define_sql_function!(fn subpath(ltree: Ltree, offset: Int4) -> Ltree);
+    define_sql_function!(fn nlevel(ltree: Ltree) -> Int4);
+    //define_sql_function!(fn index(a: Ltree, b: Ltree) -> Int4);
+    define_sql_function!(fn index(a: Ltree, b: Ltree, offset: Int4) -> Int4);
+    define_sql_function!(fn text2ltree(text: Text) -> Ltree);
+    define_sql_function!(fn ltree2text(ltree: Ltree) -> Text);
+    define_sql_function!(fn lca(ltrees: Array<Ltree>) -> Ltree);
 
-    sql_function!(fn lquery(x: Text) -> Lquery);
-    sql_function!(fn ltxtquery(x: Text) -> Ltxtquery);
+    define_sql_function!(fn lquery(x: Text) -> Lquery);
+    define_sql_function!(fn ltxtquery(x: Text) -> Ltxtquery);
 }
 
 pub mod dsl {


### PR DESCRIPTION
Adds `serde` feature which just derives `Serialize` and `Deserialize` around `values::Ltree` so that diesel models can derive serde if they wish.